### PR TITLE
Changes for Plone-6 compatibility

### DIFF
--- a/ftw/oidcauth/browser/oidc.py
+++ b/ftw/oidcauth/browser/oidc.py
@@ -2,18 +2,16 @@ from Products.Five import BrowserView
 from ftw.oidcauth.browser.oidc_tools import OIDCClientAuthentication
 from ftw.oidcauth.errors import OIDCBaseError
 from zExceptions import NotFound as zNotFound
-from zope.interface import implements
+from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound
 import logging
 
 logger = logging.getLogger('ftw.oidc')
 
-
+@implementer(IPublishTraverse)
 class OIDCView(BrowserView):
     """Endpoints for OIDC"""
-
-    implements(IPublishTraverse)
 
     def __init__(self, context, request):
         super(OIDCView, self).__init__(context, request)

--- a/ftw/oidcauth/plugin.py
+++ b/ftw/oidcauth/plugin.py
@@ -1,6 +1,6 @@
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.requestmethod import postonly
-from App.class_init import default__class_init__ as InitializeClass
+from AccessControl.class_init import default__class_init__ as InitializeClass
 from BTrees.OIBTree import OITreeSet
 from OFS.Cache import Cacheable
 from Products.CMFCore.permissions import ManagePortal
@@ -14,7 +14,7 @@ from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
 from Products.PluggableAuthService.permissions import ManageUsers
 from Products.PluggableAuthService.utils import csrf_only
 from ftw.oidcauth.helper import get_oidc_request_url
-from zope.interface import implements
+from zope.interface import implementer
 import ast
 import json
 import logging
@@ -40,15 +40,10 @@ def addOIDCPlugin(self, id_, title='', REQUEST=None):
             "%s/manage_workspace?manage_tabs_message=OIDC+Web+SSO+plugin+"
             "added." % self.absolute_url())
 
-
+@implementer(IRolesPlugin, IUserEnumerationPlugin, IChallengePlugin)
 class OIDCPlugin(BasePlugin):
     """OIDC authentication plugin.
     """
-    implements(
-        IRolesPlugin,
-        IUserEnumerationPlugin,
-        IChallengePlugin
-    )
 
     meta_type = "ftw.oidcauth plugin"
     security = ClassSecurityInfo()


### PR DESCRIPTION
I did some configuration changes for compatiblity with plone-6.

- from **AccessControl.class_init** import default__class_init__ as InitializeClass instead of from App.class_init...
- @implementer decorator instead of implements